### PR TITLE
Add StringUtils class with lowerToUpperCase method

### DIFF
--- a/dal-apis/pom.xml
+++ b/dal-apis/pom.xml
@@ -14,9 +14,9 @@
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -68,10 +68,12 @@
                         <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-surefire-plugin</artifactId>
+                                <version>3.2.5</version> 
                                 <configuration>
-                                        <excludes>
-                                                <exclude>**/*Test*.java</exclude>
-                                        </excludes>
+                                    <includes>
+                                        <include>**/*Test.java</include>
+                                        <include>**/*Tests.java</include>
+                                    </includes>
                                 </configuration>
                         </plugin>
                 </plugins>

--- a/dal-apis/src/main/java/com/example/utils/StringUtils.java
+++ b/dal-apis/src/main/java/com/example/utils/StringUtils.java
@@ -1,0 +1,21 @@
+package com.example.utils;
+
+public class StringUtils {
+
+    public static String lowerToUpperCase(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (char c : input.toCharArray()) {
+            if (Character.isLowerCase(c)) {
+                sb.append(Character.toUpperCase(c));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/dal-apis/src/test/java/com/example/utils/StringUtilsTest.java
+++ b/dal-apis/src/test/java/com/example/utils/StringUtilsTest.java
@@ -1,0 +1,37 @@
+package com.example.utils;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StringUtilsTest {
+
+    @Test
+    void testAllLowercase() {
+        assertEquals("ABCDEF", StringUtils.lowerToUpperCase("abcdef"));
+    }
+
+    @Test
+    void testMixedCase() {
+        assertEquals("ABCDEF", StringUtils.lowerToUpperCase("aBcDeF"));
+    }
+
+    @Test
+    void testAllUppercase() {
+        assertEquals("ABCDEF", StringUtils.lowerToUpperCase("ABCDEF"));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertEquals("", StringUtils.lowerToUpperCase(""));
+    }
+
+    @Test
+    void testNullString() {
+        assertEquals(null, StringUtils.lowerToUpperCase(null));
+    }
+
+    @Test
+    void testMixedWithNumbersAndSpecialChars() {
+        assertEquals("ABC123XYZ!@#", StringUtils.lowerToUpperCase("abc123XYZ!@#"));
+    }
+}


### PR DESCRIPTION
This commit introduces a new utility class `StringUtils` within the `dal-apis` module, under the `com.example.utils` package.

The `StringUtils` class includes a static method `lowerToUpperCase(String input)` which converts all lowercase characters in a given string to uppercase. The method handles null or empty input strings by returning them as is.

Unit tests have been added in `StringUtilsTest` to cover various scenarios, including:
- All lowercase strings
- Mixed-case strings
- All uppercase strings
- Empty strings
- Null strings
- Strings with numbers and special characters

The `dal-apis/pom.xml` was updated to include the JUnit 5 dependency and configure the maven-surefire-plugin for JUnit 5 test execution.